### PR TITLE
#33 Completed the MP Cloud Pre-Footer Content Block & Fix the MP Pre-Footer Accordion Block Styling

### DIFF
--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -69,64 +69,101 @@ footer {
 
 .mpcloud-pre-footer-content-block,
 .mpcloud-pre-footer-accordion-block {
+  @extend .w-100;
   display: inline-block;
   background-color: $cloud-blue-lightest;
 
   &-hr {
     position: relative;
-    height: 4px;
+    height: .25rem;
     background-color: $white;
     border: none;
-    margin: 7px 60px;
+    margin: .4rem 3.75rem;
 
     &::before,
     &::after {
       content: '';
       display: block;
       position: absolute;
-      top: -19px;
-      width: 42px;
-      height: 40px;
+      top: -1.2rem;
+      width: 2.5rem;
+      height: 2.5rem;
     }
-  
+
     &::before {
-      left: -42px;
+      left: -2.5rem;
       background: url('../assets/img/PreFooterLeft.svg');
     }
 
     &::after {
-      right: -42px;
+      right: -2.5rem;
       background: url('../assets/img/PreFooterRight.svg');
     }
   }
 
   &-container {
     @extend .container;
-    padding-top: 56px;
-    padding-right: 142px;
-    padding-bottom: 80px;
-    padding-left: 142px;
+    padding: 3rem 4rem;
+
+    @include media-breakpoint-down(sm) {
+      padding: 1.5rem;
+    }
   }
 
   &-row {
     @extend .row;
   }
 
+  &-col {
+    @extend .col;
+
+    @include media-breakpoint-down(sm) {
+      margin: 1.5rem 0;
+      flex-basis: 100%;
+    }
+  }
+
   &-title {
     @extend .col;
     @extend .text-center;
-    font-size: 48px;
+    font-size: 3rem;
     font-weight: bold;
+    margin-bottom: 3rem;
+
+    @include media-breakpoint-down(sm) {
+      font-size: 2rem;
+      margin-bottom: 0rem;
+    }
+  }
+
+  &-subtitle {
+    @extend .text-left;
+    font-size: 1.5rem;
+    font-weight: bold;
+  }
+
+  &-link {
+    color: $mp-blue;
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }
 
 .mpcloud-pre-footer-accordion {
   @extend .accordion;
   color: $mp-blue;
-  font-size: 18px;
+  font-size: 1.125rem;
+  flex-basis: 100%;
 
   &-heading {
-    padding-bottom: 8px;
+    padding-bottom: .5rem;
+  }
+
+  &-block-row {
+    margin: 0rem !important;
   }
 
   &-card {
@@ -134,27 +171,35 @@ footer {
     background: none;
     border: none;
 
+    &:not(:last-child){
+      border-bottom: 1px solid $cloud-blue-light !important;
+    }
+
     &-header {
       @extend .card-header;
       position: relative;
       background: none;
-      padding: 23px 0;
-      border-color: $cloud-blue-light;
+      padding: 1rem 0;
+      border-color: transparent;
       margin-bottom: 0 !important;
+      font-size: 1.125rem;
+      color: $mp-blue;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: nowrap;
+      align-content: center;
 
       @include media-breakpoint-up(lg) {
         white-space: nowrap;
+        align-items: center;
       }
 
-      &::after {
-        font-family: 'emtechandmpcloudIcons';
-        content: '\e90f';
+      i {
         display: block;
         position: absolute;
-        top: 35%;
-        right: 0;
-        height: 24px;
-        width: 23px;
+        top: .25rem;
+        right: .25rem;
+        font-size: 1.5rem;
         color: $cloud-blue-light;
         text-align: center;
       }
@@ -162,6 +207,12 @@ footer {
 
     &-body {
       @extend .card-body;
+      padding: 0 1rem 2rem 3.5rem;
+
+      @include media-breakpoint-up(lg) {
+        padding: 0 1rem 2rem 2.5rem;
+        max-width: 95%;
+      }
     }
   }
 
@@ -169,23 +220,43 @@ footer {
     vertical-align: middle;
 
     @include media-breakpoint-down(md) {
-      padding: 6px 12px;
+      padding: .375rem .75rem;
     }
   }
 
   &-btn-link {
     @extend .btn-link;
-    font-size: 18px;
+    font-size: 1.125rem;
     font-weight: bold;
+    color: $mp-blue;
     text-align: left;
     padding-top: 0;
-    padding-right: calc(12px + 23px);
+    padding-right: calc(.75rem + 1.5rem);
     padding-bottom: 0;
-    padding-left: 12px;
+    padding-left: .75rem;
+    padding-right: 3rem;
+    position: relative;
+    display: block !important;
+    width: 100%;
+
+
+    &:hover {
+      color: $mp-blue !important;
+      text-decoration: none !important;
+    }
   }
 
+  &-btn-link[aria-expanded="true"] i {
+    transform: rotate(-180deg);
+  }
+
+  &-btn-link[aria-expanded="false"] i {
+    transform: rotate(0deg);
+  }
+
+
   .mpcloud-pre-footer-accordion-heading {
-    margin-top: 0 !important;
+    margin-top: 0rem !important;
   }
 }
 
@@ -384,7 +455,7 @@ footer {
       width: 42px;
       height: 40px;
     }
-  
+
     &::before {
       left: -42px;
       background: url('../assets/img/FooterContentBlockDecorLeft.svg');

--- a/component-footer.md
+++ b/component-footer.md
@@ -5,15 +5,58 @@ title: Footer // Components
 
 
 # Footer
+<style>
+body > .container,
+.docs-content {
+  max-width: 100%;
+}
+
+.nl-docs .docs-content {
+  width: 100% !important;
+  flex: 0 0 100% !important;
+  max-width: 100% !important;
+}
+
+.nl-docs .docs-subnav {
+  display: none;
+}
+</style>
 
 ## MP Pre-Footer Content Block
 <div class="mpcloud-pre-footer-content-block">
   <hr class="mpcloud-pre-footer-content-block-hr">
   <div class="mpcloud-pre-footer-content-block-container">
     <div class="mpcloud-pre-footer-content-block-row">
-      <div class="mpcloud-pre-footer-content-block-title">
+      <h2 class="mpcloud-pre-footer-content-block-title">
         Helping EMS Agencies and 3rd Party Billing Companies Improve Efficiency and Profitability.
-      </div>
+      </h2>
+    </div>
+    <div class="mpcloud-pre-footer-content-block-row">
+
+    <div class="mpcloud-pre-footer-content-block-col">
+      <h3 class="mpcloud-pre-footer-content-block-subtitle">
+        Get Paid Faster Than Ever Before.
+      </h3>
+      <p>Automated Imports and One-Click Search maximizes accuracy and efficiency by reducing redundancy and human error.</p>
+      <a href="#" class="mpcloud-pre-footer-content-block-link" arial-label="AdvanceClaim for EMS Agencies">AdvanceClaim for EMS Agencies</a>
+    </div>
+
+    <div class="mpcloud-pre-footer-content-block-col">
+      <h3 class="mpcloud-pre-footer-content-block-subtitle">
+        Double Claims Processing Speed.
+      </h3>
+      <p>No more manual data entry. No more hoping it’s done in the morning. Find lost fees and revenue and see the entire financial picture.</p>
+      <a href="#" class="mpcloud-pre-footer-content-block-link" arial-label="AdvanceClaim for EMS Billing">AdvanceClaim for EMS Billing</a>
+    </div>
+
+    <div class="mpcloud-pre-footer-content-block-col">
+      <h3 class="mpcloud-pre-footer-content-block-subtitle">
+        Respond Faster. Reduce Errors.
+      </h3>
+      <p>Dispatch with confidence using one-click patient information and insurance verification. No more guesswork or manual data entry.</p>
+      <a href="#" class="mpcloud-pre-footer-content-block-link" arial-label="AdvanceDispatch">AdvanceDispatch</a>
+    </div>
+
     </div>
   </div>
 </div>
@@ -23,9 +66,36 @@ title: Footer // Components
   <hr class="mpcloud-pre-footer-content-block-hr">
   <div class="mpcloud-pre-footer-content-block-container">
     <div class="mpcloud-pre-footer-content-block-row">
-      <div class="mpcloud-pre-footer-content-block-title">
+      <h2 class="mpcloud-pre-footer-content-block-title">
         Helping EMS Agencies and 3rd Party Billing Companies Improve Efficiency and Profitability.
-      </div>
+      </h2>
+    </div>
+    <div class="mpcloud-pre-footer-content-block-row">
+
+    <div class="mpcloud-pre-footer-content-block-col">
+      <h3 class="mpcloud-pre-footer-content-block-subtitle">
+        Get Paid Faster Than Ever Before.
+      </h3>
+      <p>Automated Imports and One-Click Search maximizes accuracy and efficiency by reducing redundancy and human error.</p>
+      <a href="#" class="mpcloud-pre-footer-content-block-link" arial-label="AdvanceClaim for EMS Agencies">AdvanceClaim for EMS Agencies</a>
+    </div>
+
+    <div class="mpcloud-pre-footer-content-block-col">
+      <h3 class="mpcloud-pre-footer-content-block-subtitle">
+        Double Claims Processing Speed.
+      </h3>
+      <p>No more manual data entry. No more hoping it’s done in the morning. Find lost fees and revenue and see the entire financial picture.</p>
+      <a href="#" class="mpcloud-pre-footer-content-block-link" arial-label="AdvanceClaim for EMS Billing">AdvanceClaim for EMS Billing</a>
+    </div>
+
+    <div class="mpcloud-pre-footer-content-block-col">
+      <h3 class="mpcloud-pre-footer-content-block-subtitle">
+        Respond Faster. Reduce Errors.
+      </h3>
+      <p>Dispatch with confidence using one-click patient information and insurance verification. No more guesswork or manual data entry.</p>
+      <a href="#" class="mpcloud-pre-footer-content-block-link" arial-label="AdvanceDispatch">AdvanceDispatch</a>
+    </div>
+
     </div>
   </div>
 </div>
@@ -41,8 +111,9 @@ title: Footer // Components
         <div class="mpcloud-pre-footer-accordion-card">
           <div class="mpcloud-pre-footer-accordion-card-header" id="headingOne">
             <span class="mpcloud-pre-footer-accordion-number">01</span>
-            <button class="btn mpcloud-pre-footer-accordion-btn-link" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+            <button class="btn mpcloud-pre-footer-accordion-btn-link" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
               Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum?
+              <i class="mpcloud-icon icon-chevron-down"></i>
             </button>
           </div>
           <div id="collapseOne" class="collapse show" aria-labelledby="headingOne" data-parent="#mpcloudAccordion">
@@ -56,6 +127,7 @@ title: Footer // Components
             <span class="mpcloud-pre-footer-accordion-number">02</span>
             <button class="btn mpcloud-pre-footer-accordion-btn-link" type="button" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
               Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum?
+              <i class="mpcloud-icon icon-chevron-down"></i>
             </button>
           </div>
           <div id="collapseTwo" class="collapse" aria-labelledby="headingTwo" data-parent="#mpcloudAccordion">
@@ -69,6 +141,7 @@ title: Footer // Components
             <span class="mpcloud-pre-footer-accordion-number">03</span>
             <button class="btn mpcloud-pre-footer-accordion-btn-link" type="button" data-toggle="collapse" data-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
               Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum?
+              <i class="mpcloud-icon icon-chevron-down"></i>
             </button>
           </div>
           <div id="collapseThree" class="collapse" aria-labelledby="headingThree" data-parent="#mpcloudAccordion">
@@ -92,8 +165,9 @@ title: Footer // Components
         <div class="mpcloud-pre-footer-accordion-card">
           <div class="mpcloud-pre-footer-accordion-card-header" id="headingOne">
             <span class="mpcloud-pre-footer-accordion-number">01</span>
-            <button class="btn mpcloud-pre-footer-accordion-btn-link" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+            <button class="btn mpcloud-pre-footer-accordion-btn-link" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
               Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum?
+              <i class="mpcloud-icon icon-chevron-down"></i>
             </button>
           </div>
           <div id="collapseOne" class="collapse show" aria-labelledby="headingOne" data-parent="#mpcloudAccordion">
@@ -107,6 +181,7 @@ title: Footer // Components
             <span class="mpcloud-pre-footer-accordion-number">02</span>
             <button class="btn mpcloud-pre-footer-accordion-btn-link" type="button" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
               Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum?
+              <i class="mpcloud-icon icon-chevron-down"></i>
             </button>
           </div>
           <div id="collapseTwo" class="collapse" aria-labelledby="headingTwo" data-parent="#mpcloudAccordion">
@@ -120,6 +195,7 @@ title: Footer // Components
             <span class="mpcloud-pre-footer-accordion-number">03</span>
             <button class="btn mpcloud-pre-footer-accordion-btn-link" type="button" data-toggle="collapse" data-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
               Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum?
+              <i class="mpcloud-icon icon-chevron-down"></i>
             </button>
           </div>
           <div id="collapseThree" class="collapse" aria-labelledby="headingThree" data-parent="#mpcloudAccordion">


### PR DESCRIPTION
This closes #33 

To test correctly for all breakpoints. IF/When you pull down the PR add the following code to the bottom of the 'component-footer.md' page markup.

`<style>
body > .container,
.docs-content {
max-width: 100%;
}

.nl-docs .docs-content {
width: 100% !important;
flex: 0 0 100% !important;
max-width: 100% !important;
}

.nl-docs .docs-subnav {
display: none;
}
</style>`